### PR TITLE
while catalog_viewer.close function is called, set s:is_buffergator_buffers_open to zero.

### DIFF
--- a/autoload/buffergator.vim
+++ b/autoload/buffergator.vim
@@ -737,6 +737,7 @@ function! s:NewCatalogViewer(name, title)
             endif
         endif
         execute("bwipe " . self.bufnum)
+        let s:is_buffergator_buffers_open = 0
     endfunction
 
     function! catalog_viewer.expand_screen() dict
@@ -1891,7 +1892,7 @@ function! buffergator#UpdateBuffergator(event, affected)
 endfunction
 
 function! buffergator#CloseBuffergator()
-    let s:is_buffergator_buffers_open = 0
+    "let s:is_buffergator_buffers_open = 0
     call s:_catalog_viewer.close(1)
 endfunction
 


### PR DESCRIPTION
When I press `q` or `enter` in buffergator window,the window will closed and `s:is_bufferagor_buffers_open` is still one.I must call `:BuffergatorToggle` twice to reopen buffergator window.The first time set `s:is_buffergator_buffers_open` to zero,the second time call `:BuffergatorOpen`.