### PR TITLE
set filetype for buffergator

### DIFF
--- a/autoload/buffergator.vim
+++ b/autoload/buffergator.vim
@@ -684,6 +684,7 @@ function! s:NewCatalogViewer(name, title)
         setlocal cursorline
         setlocal nospell
         setlocal matchpairs=""
+        setlocal filetype=buffergator
     endfunction
 
     " Sets buffer commands.


### PR DESCRIPTION
... so that one can conveniently use autocmd on it. e.g. to prevent switching
buffers within buffergator splits. see:
http://stackoverflow.com/questions/10216917/prevent-certain-command-mappings-while-focused-on-nerdtree