### PR TITLE
Add blacklist option

### DIFF
--- a/autoload/buffergator.vim
+++ b/autoload/buffergator.vim
@@ -71,6 +71,9 @@ endif
 if !exists("g:buffergator_mru_cycle_local_to_window")
     let g:buffergator_mru_cycle_local_to_window = 1
 endif
+if !exists("g:buffergator_blacklist")
+    let g:buffergator_blacklist = []
+endif
 " 1}}}
 
 " Script Data and Variables {{{1
@@ -507,6 +510,16 @@ function! s:NewCatalogViewer(name, title)
         let self.max_buffer_basename_len = 0
         let l:buffers_output_rows = split(l:buffers_output, "\n")
         for l:buffers_output_row in l:buffers_output_rows
+            let l:blacklist_match = 0
+            for l:blacklisted_name in g:buffergator_blacklist
+              if !empty(matchstr(l:buffers_output_row, l:blacklisted_name))
+                let l:blacklist_match = 1
+                continue
+              end
+            endfor
+            if l:blacklist_match
+              continue
+            endif
             let l:parts = matchlist(l:buffers_output_row, '^\s*\(\d\+\)\(.....\) "\(.*\)"')
             let l:info = {}
             let l:info["bufnum"] = l:parts[1] + 0

--- a/doc/buffergator.txt
+++ b/doc/buffergator.txt
@@ -334,4 +334,10 @@ g:buffergator_mru_cycle_local_to_window~
     If true, then the most recently used list will include only buffers
     within the window.  Otherwise, it will incude all buffers.
 
+g:buffergator_blacklist~
+    Default: []
+    Sets a list of blacklisted buffer names that you don't want to
+    pop up in the Buffergator catalog. Doesn't need to be a full match.
+    Example: ["term:\/\/"]
+
  vim:tw=78:ts=8:ft=help:norl:


### PR DESCRIPTION
After installing neoterm I discovered that it keeps terminal buffer constantly open, so it pops up in buffergator list. Having it there is not what I want, especially when opening it through buffergator leads to weird behaviour of vim windows. I thought that it would be cool to have a blacklist in buffergator, that hides certain buffers from the list, and here it is.

Disclaimer: this is my first time touching vimscript, so corrections are appreciated.
