### PR TITLE
Add option to disable statusline modification.

### DIFF
--- a/autoload/buffergator.vim
+++ b/autoload/buffergator.vim
@@ -71,6 +71,12 @@ endif
 if !exists("g:buffergator_mru_cycle_local_to_window")
     let g:buffergator_mru_cycle_local_to_window = 1
 endif
+if !exists("g:buffergator_tab_statusline")
+    let g:buffergator_tab_statusline = 1
+endif
+if !exists("g:buffergator_window_statusline")
+    let g:buffergator_window_statusline = 1
+endif
 " 1}}}
 
 " Script Data and Variables {{{1
@@ -1560,7 +1566,9 @@ function! s:NewBufferCatalogViewer()
 
     " Sets buffer status line.
     function! catalog_viewer.setup_buffer_statusline() dict
-        setlocal statusline=%{BuffergatorBuffersStatusLine()}
+        if g:buffergator_window_statusline
+            setlocal statusline=%{BuffergatorBuffersStatusLine()}
+        endif
     endfunction
 
     " Appends a line to the buffer and registers it in the line log.
@@ -1759,7 +1767,9 @@ function! s:NewTabCatalogViewer()
     endfunction
 
     function! catalog_viewer.setup_buffer_statusline() dict
-        setlocal statusline=%{BuffergatorTabsStatusLine()}
+        if g:buffergator_tab_statusline
+            setlocal statusline=%{BuffergatorTabsStatusLine()}
+        endif
     endfunction
 
     " return object

--- a/doc/buffergator.txt
+++ b/doc/buffergator.txt
@@ -329,6 +329,16 @@ g:buffergator_suppress_keymaps~
     If true, then Buffergator will not automatically map "<Leader>b" to
     open the Buffergator catalog and "<Leader>B" to close it.
 
+g:buffergator_tab_statusline~
+    Default: 1
+    If true, then Buffergator will not modify the statusline for the tab
+    buffer catalog.
+
+g:buffergator_window_statusline~
+    Default: 1
+    If true, then Buffergator will not modify the statusline for the window
+    buffer catalog.
+
 g:buffergator_mru_cycle_local_to_window~
     Default: 1
     If true, then the most recently used list will include only buffers


### PR DESCRIPTION
I really like your plugin, It's exactly what I was looking for but I felt this little twik was needed to make it perfect for me because I use [`airline`](https://github.com/vim-airline/vim-airline).
I was trying to add an [extension for `airline`](https://github.com/vim-airline/vim-airline/blob/master/doc/airline.txt#L253) for your plugin but It's **perhaps** a little bit hard at the moment because of the way your plugin is built with all the dictionaries.
What do you think?