### PR TITLE
Add option to exclusively MRU cycle through the two MRU buffers

### DIFF
--- a/autoload/buffergator.vim
+++ b/autoload/buffergator.vim
@@ -350,6 +350,9 @@ function! s:_is_full_height_window(win_num)
     endif
 endfunction!
 
+let g:buffergator__has_cycled = 0
+let g:buffergator__buf_prev = 0
+
 function! s:_find_mru_bufnr(dir)
     let l:cur_buf_idx = index(w:buffergator_mru, bufnr("%"))
     if len(w:buffergator_mru) < 1 " maybe should be 2?
@@ -359,9 +362,31 @@ function! s:_find_mru_bufnr(dir)
         let l:target_buf_idx = 0
     else
         if a:dir < 0
-            let l:target_buf_idx = l:cur_buf_idx + 1 " deeper in list = older
+            if g:buffergator_mru_cycle_loop_last_two
+                if !g:buffergator__has_cycled
+                    let l:target_buf_idx = l:cur_buf_idx + 1 " deeper in list = older
+                    let g:buffergator__buf_prev = l:cur_buf_idx
+                    let g:buffergator__has_cycled = 1
+                else
+                    let l:target_buf_idx = g:buffergator__buf_prev
+                    let g:buffergator__buf_prev = l:cur_buf_idx
+                endif
+            else
+                let l:target_buf_idx = l:cur_buf_idx + 1 " deeper in list = older
+            endif
         else
-            let l:target_buf_idx = l:cur_buf_idx - 1 " up list = newer
+            if g:buffergator_mru_cycle_loop_last_two
+                if !g:buffergator__has_cycled
+                    let l:target_buf_idx = l:cur_buf_idx - 1 " up list = newer
+                    let g:buffergator__buf_prev = l:cur_buf_idx
+                    let g:buffergator__has_cycled = 1
+                else
+                    let l:target_buf_idx = g:buffergator__buf_prev
+                    let g:buffergator__buf_prev = l:cur_buf_idx
+                endif
+            else
+                let l:target_buf_idx = l:cur_buf_idx - 1 " up list = newer
+            endif
         endif
     endif
     if l:target_buf_idx < 0

--- a/doc/buffergator.txt
+++ b/doc/buffergator.txt
@@ -91,12 +91,20 @@ key mappings are defined:
                           (default), then this will loop, i.e. returning to
                           the initial buffer after reaching the oldest buffer.
 
+                          If "g:buffergator_mru_cycle_loop_last_two" is set to
+                          1, then only the last two accessed buffers will be
+                          cycled.
+
 ]b, <M-S-B>               Invokes ":BuffergatorMruCycleNext": cycle to a newer
                           buffer in the most-recently used (MRU) buffer list.
                           most-recently used buffer. If
                           "g:buffergator_mru_cycle_loop" is set to 1
                           (default), then this will loop, i.e. returning to
                           the oldest buffer after reaching the newest buffer.
+
+                          If "g:buffergator_mru_cycle_loop_last_two" is set to
+                          1, then only the last two accessed buffers will be
+                          cycled.
 
 Unless either "g:buffergator_suppress_keymaps" or
 "g:buffergator_suppress_mru_switching_keymaps" is set to 1, then the following

--- a/plugin/buffergator.vim
+++ b/plugin/buffergator.vim
@@ -36,6 +36,9 @@ set cpo&vim
 if !exists("g:buffergator_mru_cycle_loop")
     let g:buffergator_mru_cycle_loop = 1
 endif
+if !exists("g:buffergator_mru_cycle_loop_last_two")
+    let g:buffergator_mru_cycle_loop_last_two = 0
+endif
 let g:buffergator_track_mru = 1
 let g:buffergator_mru = []
 function! BuffergatorUpdateMRU(acmd_bufnr)


### PR DESCRIPTION
In my humble opinion, it's almost impossible to remember more than the
last two used buffers. Therefore, it would make sense that there's an
option to enable cycling through the last two used buffers, which is
what I want most of the time. I am confident I'm not alone in this.

This patch implements that functionality.

This would close #82